### PR TITLE
Unify TokyoNight Storm theme and improve shell/tmux integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 
 .PHONY: install install/*
 
-install: install/brew install/asdf install/python install/nvim install/fish install/git install/tmux
+install: install/brew install/asdf install/python install/nvim install/fish install/git install/tmux install/claude
 
 install/brew:
 	which brew || /bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -48,6 +48,11 @@ install/tmux:
 install/git:
 	ln -siv $(PWD)/git/gitconfig ~/.gitconfig
 	ln -siv $(PWD)/git/gitignore_global ~/.gitignore_global
+
+install/claude:
+	mkdir -p ~/.claude
+	ln -siv $(PWD)/claude/settings.json ~/.claude/settings.json
+	ln -siv $(PWD)/claude/statusline.sh ~/.claude/statusline.sh
 
 #
 # Export

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,100 @@
+{
+	"env": {
+		"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+	},
+	"permissions": {
+		"allow": []
+	},
+	"hooks": {},
+	"statusLine": {
+		"type": "command",
+		"command": "bash ~/.claude/statusline.sh"
+	},
+	"enabledPlugins": {
+		"document-skills@anthropic-agent-skills": true,
+		"code-review@claude-code-plugins": true,
+		"commit-commands@claude-plugins-official": true,
+		"figma@claude-plugins-official": false,
+		"frontend-design@claude-plugins-official": true,
+		"typescript-lsp@claude-plugins-official": true,
+		"security-guidance@claude-plugins-official": true,
+		"Notion@claude-plugins-official": true,
+		"swift-lsp@claude-plugins-official": false,
+		"context7@claude-plugins-official": true,
+		"code-simplifier@claude-plugins-official": true,
+		"pr-review-toolkit@claude-code-plugins": true,
+		"ralph-loop@claude-plugins-official": true,
+		"plugin-dev@claude-plugins-official": true,
+		"coderabbit@claude-plugins-official": true
+	},
+	"language": "Japanese",
+	"mcpServers": {
+		"Context7": {
+			"command": "npx",
+			"args": ["-y", "@upstash/context7-mcp"]
+		},
+		"Figma": {
+			"url": "http://127.0.0.1:3845/sse"
+		},
+		"github": {
+			"command": "npx",
+			"args": ["@modelcontextprotocol/server-github"],
+			"env": {
+				"GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+			}
+		},
+		"playwright": {
+			"command": "npx",
+			"args": ["@modelcontextprotocol/server-playwright"]
+		},
+		"sequential-thinking": {
+			"command": "npx",
+			"args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+		},
+		"xcode-build": {
+			"command": "npx",
+			"args": ["@modelcontextprotocol/server-xcode-build"]
+		},
+		"permissions": {
+			"allow": [
+				"Skill(agent-browser:*)",
+				"mcp__plugin_context7_context7__*",
+				"mcp__plugin_Notion_notion__*",
+				"Bash(agent-browser:*)",
+				"Bash(cd:*)",
+				"Bash(echo:*)",
+				"Bash(ls:*)",
+				"Bash(mkdir:*)",
+				"Bash(mv:*)",
+				"Bash(pwd:*)",
+				"Bash(grep:*)",
+				"Bash(rg:*)",
+				"Bash(head:*)",
+				"Bash(tail:*)",
+				"Bash(sed:*)",
+				"Bash(find:*)",
+				"Bash(fd:*)",
+				"Bash(ni:*)",
+				"Bash(nr:*)",
+				"Bash(nup:*)",
+				"Bash(nun:*)",
+				"Bash(nci:*)",
+				"Bash(nd:*)",
+				"Bash(na:*)",
+				"Bash(nlx:*)",
+				"Bash(xcodebuild:*)"
+			],
+			"deny": [
+				"Read(.env.*)",
+				"Write(.env*)",
+				"Read(~/.ssh/*)",
+				"Write(~/.ssh/*)",
+				"Write(**/secrets/**)",
+				"Bash(sudo:*)",
+				"Bash(rm:*)",
+				"Bash(rm -rf:*)",
+				"Bash(nc:*)"
+			]
+		}
+	}
+}

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+input=$(cat)
+
+# --- Extract data ---
+model=$(echo "$input" | jq -r '.model.display_name // .model.id')
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+cwd=$(echo "$input" | jq -r '.workspace.current_dir')
+
+# --- Icons (Nerd Font, raw UTF-8 bytes) ---
+icon_model=$(echo -e '\xEF\x84\xA1')        # U+F121 nf-fa-code
+icon_ctx=$(echo -e '\xF3\xB1\x83\xBE')      # U+F10FE nf-md-tank
+icon_dir=$(echo -e '\xEF\x81\xBC')           # U+F07C nf-fa-folder_open
+icon_branch=$(echo -e '\xEE\x9C\xA5')       # U+E725 nf-dev-git_branch
+icon_worktree=$(echo -e '\xEF\x86\xBB')     # U+F1BB nf-fa-tree
+
+# --- Colors (Tokyo Night Storm) ---
+reset=$'\033[0m'
+dim=$'\033[2m'
+green=$'\033[38;2;115;218;202m'   # #73daca
+yellow=$'\033[38;2;224;175;104m'  # #e0af68
+red=$'\033[38;2;247;118;142m'     # #f7768e
+
+sep="${dim} │ ${reset}"
+
+# --- Model ---
+model_section="${dim}${icon_model}${reset}  ${model}"
+
+# --- Context usage (% only) ---
+if [ -n "$used_pct" ] && [ "$used_pct" != "null" ]; then
+  ui=${used_pct%.*}
+  if [ "$ui" -ge 80 ]; then
+    ctx_color=$red
+  elif [ "$ui" -ge 50 ]; then
+    ctx_color=$yellow
+  else
+    ctx_color=""
+  fi
+  ctx_section="${dim}${icon_ctx}${reset} ${ctx_color}${ui}%${reset}"
+else
+  ctx_section="${dim}${icon_ctx}${reset} --%"
+fi
+
+# --- Directory ---
+dir_name=$(basename "$cwd")
+dir_section="${dim}${icon_dir}${reset}  ${dir_name}"
+
+# --- Git ---
+git_section=""
+cd "$cwd" 2>/dev/null || cd /
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ -n "$branch" ]; then
+    git_dir=$(git rev-parse --git-dir 2>/dev/null)
+    if [ -f "$cwd/.git" ] || [[ "$git_dir" == *"/worktrees/"* ]]; then
+      git_icon="${icon_worktree} ${icon_branch}"
+    else
+      git_icon="${icon_branch}"
+    fi
+    # --- Diff stats ---
+    diff_stat=$(git diff --numstat 2>/dev/null | awk '{a+=$1; d+=$2} END {printf "%d %d", a+0, d+0}')
+    additions=${diff_stat% *}
+    deletions=${diff_stat#* }
+    diff_info=""
+    if [ "$additions" -gt 0 ] || [ "$deletions" -gt 0 ]; then
+      diff_info=" ${green}+${additions}${reset} ${red}-${deletions}${reset}"
+    fi
+
+    git_section="${dim}${git_icon}${reset} ${branch}${diff_info}"
+  fi
+fi
+
+# --- Output ---
+output="${model_section}${sep}${ctx_section}${sep}${dir_section}"
+[ -n "$git_section" ] && output="${output}${sep}${git_section}"
+
+printf '%s\n' "$output"

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -1,4 +1,12 @@
 # ====================
+# Auto-start tmux
+# ====================
+
+if status is-interactive; and not set -q TMUX; and test "$TERM_PROGRAM" = ghostty
+    tmux new-session -A -s main
+end
+
+# ====================
 # Keybinding
 # ====================
 
@@ -155,6 +163,12 @@ set -gx LIBRARY_PATH "$(brew --prefix zstd)/lib" $LIBRARY_PATH
 set -gx GRPC_PYTHON_BUILD_SYSTEM_OPENSSL 1
 set -gx GRPC_PYTHON_BUILD_SYSTEM_ZLIB 1
 
+# for 1Password CLI (tokens)
+source $HOME/.config/op/plugins.sh
+if command -q op
+    set -gx GITHUB_TOKEN (op read "op://Personal/GitHub PAT - MCP/credential" --no-newline 2>/dev/null)
+end
+
 # for Rust
 fish_add_path $HOME/.cargo/bin
 
@@ -162,11 +176,20 @@ fish_add_path $HOME/.cargo/bin
 fish_add_path $HOME/fvm/default/bin
 set -gx FLUTTER_ROOT $(which flutter)
 
-# Remove duplicate PATH
-set -gx PATH (echo $PATH | tr ' ' '\n' | sort -u)
-
 # zoxide
 zoxide init fish | source
+
+# Added by Antigravity
+fish_add_path $HOME/.antigravity/antigravity/bin
+
+# Remove duplicate PATH (preserving order)
+set -l unique_path
+for p in $PATH
+    if not contains $p $unique_path
+        set -a unique_path $p
+    end
+end
+set -gx PATH $unique_path
 
 # ====================
 # Auto generated settings
@@ -176,11 +199,3 @@ zoxide init fish | source
 if [ -f '$HOME/google-cloud-sdk/path.fish.inc' ]
     . '$HOME/google-cloud-sdk/path.fish.inc'
 end
-
-# The next line updates PATH for the Google Cloud SDK.
-if [ -f '$HOME/google-cloud-sdk/path.fish.inc' ]
-    . '$HOME/google-cloud-sdk/path.fish.inc'
-end
-
-# Added by Antigravity
-fish_add_path /Users/simorgh3196/.antigravity/antigravity/bin

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,10 +1,11 @@
-theme = tokyonight
+theme = TokyoNight Storm
 
 shell-integration-features = no-cursor
 cursor-style = underline
 cursor-style-blink = false
 
 window-padding-x = 8
+window-padding-color = extend
 
 clipboard-trim-trailing-spaces = true
 clipboard-paste-protection = true

--- a/nvim/lua/config/autocmds.lua
+++ b/nvim/lua/config/autocmds.lua
@@ -1,3 +1,15 @@
+-- Dim background on tmux pane focus lost
+vim.api.nvim_create_autocmd("FocusLost", {
+  callback = function()
+    vim.cmd("hi Normal guibg=#1f2335")
+  end,
+})
+vim.api.nvim_create_autocmd("FocusGained", {
+  callback = function()
+    vim.cmd("hi Normal guibg=#24283b")
+  end,
+})
+
 -- iOS  development
 vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
   pattern = { "*.podspec", "Podfile", "Appfile", "Fastfile", "Matchfile", "Pluginfile" },

--- a/nvim/lua/plugins/colorscheme.lua
+++ b/nvim/lua/plugins/colorscheme.lua
@@ -1,3 +1,3 @@
 return {
-  { "folke/tokyonight.nvim", opts = { style = "moon" } },
+  { "folke/tokyonight.nvim", opts = { style = "storm" } },
 }

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -12,6 +12,12 @@ set -g default-shell /opt/homebrew/bin/fish
 set -g base-index 1
 set -g pane-base-index 1
 set -g renumber-windows on
+set -g automatic-rename on
+set -g automatic-rename-format '#{b:pane_current_path}'
+
+# Pass terminal title to Ghostty
+set -g set-titles on
+set -g set-titles-string '#S | #W - #{b:pane_current_path}'
 
 set -g mouse on
 set -sg escape-time 0
@@ -22,13 +28,27 @@ set -g display-panes-time 2000
 # Tokyo Night theme (storm variant to match nvim's moon)
 set -g @tokyo-night-tmux_theme storm
 
+# Window number style
+set -g @tokyo-night-tmux_window_id_style digital
+set -g @tokyo-night-tmux_window_tidy_icons 0
+
+# Status bar widgets
+set -g @tokyo-night-tmux_show_path 1
+set -g @tokyo-night-tmux_path_format relative
+set -g @tokyo-night-tmux_show_wbg 1
+
 # Dim inactive panes
-set -g window-style 'bg=#1E2030'
-set -g window-active-style 'bg=#222436'
+set -g window-style 'bg=#1f2335'
+set -g window-active-style 'bg=default'
 
 # =============================================================================
 # Key Bindings
 # =============================================================================
+
+# Prefix key
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
 
 set -g mode-keys vi
 


### PR DESCRIPTION
## Summary
- TokyoNight カラースキームを ghostty, nvim, tmux 全体で Storm バリアントに統一
- fish シェルで Ghostty 内での tmux 自動起動を追加
- tmux の非アクティブペインに対応した nvim のフォーカス dimming を追加
- tmux プレフィックスキーを `C-a` に変更し、ウィンドウの自動リネーム設定を追加
- fish で 1Password CLI によるトークン管理（GITHUB_TOKEN）を統合
- PATH 重複除去を順序保持する方式に修正
- Claude Code 設定ファイルを dotfiles に追加

## Test plan
- [ ] `make install` で全セットアップが正常に完了すること
- [ ] Ghostty + tmux + nvim でカラースキームが統一されていること
- [ ] tmux 内のペインフォーカス切替で dimming が動作すること
- [ ] fish 起動時に tmux セッションが自動アタッチされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)