### PR TITLE
herdrをdotfiles管理に統合（自動起動・Ghostty調整・インストール/設定管理）

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -1,9 +1,13 @@
 # ====================
-# Auto-start tmux
+# Auto-start herdr
 # ====================
 
-if status is-interactive; and not set -q TMUX; and test "$TERM_PROGRAM" = ghostty; and not set -q CMUX_PANEL_ID
-    tmux new-session -A -s main
+if status is-interactive; and not set -q HERDR_SESSION; and not set -q HERDR_PANE_ID; and not set -q TMUX; and test "$TERM_PROGRAM" = ghostty; and not set -q CMUX_PANEL_ID
+    if type -q herdr
+        herdr
+    else if test -x $HOME/.local/bin/herdr
+        $HOME/.local/bin/herdr
+    end
 end
 
 # ====================

--- a/ghostty/config
+++ b/ghostty/config
@@ -16,3 +16,52 @@ auto-update = check
 keybind = shift+enter=text:\n
 
 macos-option-as-alt = left
+
+# ====================
+# herdrをメインで使うため、Ghosttyの分割・タブ機能を無効化
+# ====================
+
+# タブバーを常に非表示
+window-show-tab-bar = never
+
+# タブ関連のショートカットを無効化
+keybind = super+t=unbind
+keybind = super+alt+w=unbind
+keybind = super+shift+[=unbind
+keybind = super+shift+]=unbind
+keybind = ctrl+tab=unbind
+keybind = ctrl+shift+tab=unbind
+keybind = super+1=unbind
+keybind = super+2=unbind
+keybind = super+3=unbind
+keybind = super+4=unbind
+keybind = super+5=unbind
+keybind = super+6=unbind
+keybind = super+7=unbind
+keybind = super+8=unbind
+keybind = super+9=unbind
+keybind = super+digit_1=unbind
+keybind = super+digit_2=unbind
+keybind = super+digit_3=unbind
+keybind = super+digit_4=unbind
+keybind = super+digit_5=unbind
+keybind = super+digit_6=unbind
+keybind = super+digit_7=unbind
+keybind = super+digit_8=unbind
+keybind = super+digit_9=unbind
+
+# 画面分割関連のショートカットを無効化
+keybind = super+d=unbind
+keybind = super+shift+d=unbind
+keybind = super+[=unbind
+keybind = super+]=unbind
+keybind = super+shift+enter=unbind
+keybind = super+alt+arrow_up=unbind
+keybind = super+alt+arrow_down=unbind
+keybind = super+alt+arrow_left=unbind
+keybind = super+alt+arrow_right=unbind
+keybind = super+ctrl+arrow_up=unbind
+keybind = super+ctrl+arrow_down=unbind
+keybind = super+ctrl+arrow_left=unbind
+keybind = super+ctrl+arrow_right=unbind
+keybind = super+ctrl+equal=unbind


### PR DESCRIPTION
## 概要
herdr をメインのターミナルワークスペースマネージャーとして使うための設定変更一式。

## 変更内容
### fish
- Ghostty 起動時の自動起動を tmux から herdr に変更
- 多重起動防止ガード（HERDR_SESSION / HERDR_PANE_ID / TMUX / CMUX_PANEL_ID）付き
- config.fish の PATH 設定より前に実行されるため、PATH に無い場合は ~/.local/bin/herdr へフォールバック

### Ghostty
- タブバーを常に非表示（window-show-tab-bar = never）
- タブ・画面分割関連のデフォルトショートカットをすべて unbind（⌘T, ⌘D, ⌘1-9, ⌘[ ] など）

### herdr のインストール・設定管理
- Brewfile に `brew "herdr"` を追加（homebrew-core、現行と同じ v0.7.3）
- 設定を `herdr/config.toml` としてリポジトリ管理し、`make install/herdr` で ~/.config/herdr/config.toml にシンボリックリンク
- README の構成表に herdr を追記

## 動作確認
- fish --no-execute による構文チェック済み
- ghostty +validate-config によるバリデーション済み
- make -n install/herdr の dry-run と brew bundle list による Brewfile パース確認済み

## 備考
- 既存の ~/.local/bin/herdr（公式インストーラー版）は brew 版と重複するため、マージ後に削除推奨（`rm ~/.local/bin/herdr`）。fish 側のフォールバックがあるため残していても動作はします
- ~/.config/herdr/config.toml は既存ファイルがあるため、`make install/herdr` 実行時に上書き確認が出ます

🤖 Generated with [Claude Code](https://claude.com/claude-code)